### PR TITLE
Modify Docker Compose setup to create a GPU-less container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,14 @@ FROM ubuntu20.04 AS noetic
 ENV ROS_DISTRO=noetic
 
 # Install ROS Noetic, using the standard instructions (without sudo)
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get -y install lsb-release curl && \
+RUN apt-get -y install lsb-release curl gnupg && \
     sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' && \
     curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add - && \
     apt-get update && \
-    apt-get -y install ros-noetic-desktop-full && \
+    apt-get clean
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y install ros-noetic-desktop-full
+RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -y install python3-rosdep python3-rosinstall python3-rosinstall-generator python3-wstool build-essential && \
     apt-get clean && \
     rosdep init && \
@@ -44,8 +46,8 @@ RUN mkdir -p /ws_moveit/src && \
     cd /ws_moveit/src && \
     git clone https://github.com/moveit/moveit_tutorials.git -b master --depth 1 && \
     git clone https://github.com/moveit/panda_moveit_config.git -b noetic-devel --depth 1 && \
-    rosdep -y install --from-paths . --ignore-src --rosdistro noetic && \
-    cd /ws_moveit && \
+    rosdep -y install --from-paths . --ignore-src --rosdistro noetic
+RUN cd /ws_moveit && \
     catkin config --extend /opt/ros/${ROS_DISTRO} --cmake-args -DCMAKE_BUILD_TYPE=Release && \
     catkin build && \
     echo "source /ws_moveit/devel/setup.bash" >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #   To find which CUDA toolkit versions your driver supports, see Table 2:
 #       https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
 #
-#   For reference, Benned's driver version (535.183.01) supports CUDA toolkit 12.2.2
+# For reference, Benned's driver version (535.183.01) supports CUDA toolkit 12.2.2
 ARG CUDA_VERSION=12.2.2
 
 # Enable overriding the base image for non-GPU machines (default uses GPU)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ xhost +local:docker
 docker compose attach noetic-nvidia
 ```
 
+To enter the running container in another terminal, run the command:
+```bash
+docker compose exec noetic-nvidia bash
+```
+
 ### GPU-less Container
 
 The Docker Compose configuration for this repository also supports a container for machines without an NVIDIA GPU. To build and start the GPU-less container, run the command:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,30 @@ Motion-planning-based skills for Boston Dynamics' Spot robot
 
 ## Docker Commands
 
-This repository uses Docker to manage dependencies. To build and start the GPU-enabled container, run the command:
+This repository uses Docker to manage dependencies. Docker Compose is used to configure the necessary images and containers, supporting both a GPU-enabled and GPU-less container.
+
+### GPU-enabled Container
+
+The Docker Compose configuration for this repository supports a container for machines with an NVIDIA GPU. To build and start the GPU-enabled container, run the command:
 ```bash
-docker compose up --build --detach
+docker compose up --build --detach noetic-nvidia
 ```
 
 Then, to enter the container, run the following commands:
 ```bash
 xhost +local:docker
 docker compose attach noetic-nvidia
+```
+
+### GPU-less Container
+
+The Docker Compose configuration for this repository also supports a container for machines without an NVIDIA GPU. To build and start the GPU-less container, run the command:
+```bash
+docker compose up --build --detach noetic-no-gpu
+```
+
+Then, to enter the container, run the following commands:
+```bash
+xhost +local:docker
+docker compose attach noetic-no-gpu
 ```

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,29 +1,23 @@
 services:
-  noetic-nvidia:
-    build: .
-    environment:
-      - DISPLAY # Pass the DISPLAY environment variable for X11 forwarding
-      - QT_X11_NO_MITSHM=1 # Prevent Qt apps in the container from using the MIT-SHM extension for X11
-      - TERM # Pass the TERM environment variable specifying the terminal type
-      - color_prompt=yes # Provide a colored prompt in the container
 
+  # This service creates a container running Ubuntu 20.04 with ROS 1 Noetic installed
+  noetic-no-gpu:
+    extends: # Extend a service providing the config needed to run GUIs from the container
+      file: ./docker/gui-compose.yaml
+      service: base-gui
+    # TODO: Modify the base image, somehow!
+    build: .
+  
+  # This service adds NVIDIA GPU support to our Ubuntu 20.04 and ROS 1 Noetic setup
+  noetic-nvidia: # This NVIDIA GPU support
+    extends: # Extend a service providing the config needed to run GUIs from the container
+      file: ./docker/gui-compose.yaml
+      service: base-gui
+    build: .
+    environment: # Additional NVIDIA-required environment variables
       - NVIDIA_VISIBLE_DEVICES=all # Ensure that the container can access all NVIDIA devices
       - NVIDIA_DRIVER_CAPABILITIES=all # Enable all NVIDIA driver capabilities for container
-      - __NV_PRIME_RENDER_OFFLOAD=1 # Offload graphics applications to the NVIDIA GPU
-      - __GLX_VENDOR_LIBRARY_NAME=nvidia # Specify to use the NVIDIA driver for GLX graphics
-
-      # Run `drm-info` to view your machine's DRM device info
-      - DRI_NAME=card1 # Set the DRI (Direct Rendering Infrastructure) device to the GPU
     network_mode: host # Share the host's network
-    devices:
-      - "/dev/dri:/dev/dri"
-    volumes:
-      - /tmp/.X11-unix:/tmp/.X11-unix # Mount the X11 Unix socket to support GUIs
-      - .:/spot_skills # Mount the current directory (should be the ROS workspace)
-      - /etc/localtime:/etc/localtime:ro # Sync the container's timezone with the host (read-only)
-    
-    stdin_open: true    # docker run -i
-    tty: true           # docker run -t
     deploy:
       resources:
         reservations:   # Host machine must guarantee the container these resources

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,15 +1,17 @@
 services:
 
-  # This service creates a container running Ubuntu 20.04 with ROS 1 Noetic installed
+  # This service creates a container running Ubuntu 20.04 with ROS 1 Noetic
   noetic-no-gpu:
     extends: # Extend a service providing the config needed to run GUIs from the container
       file: ./docker/gui-compose.yaml
       service: base-gui
-    # TODO: Modify the base image, somehow!
-    build: .
+    build:
+      context: .
+      args:
+        BASE_IMAGE: ubuntu:20.04 # Use a CUDA-less base image for the GPU-less service
   
   # This service adds NVIDIA GPU support to our Ubuntu 20.04 and ROS 1 Noetic setup
-  noetic-nvidia: # This NVIDIA GPU support
+  noetic-nvidia:
     extends: # Extend a service providing the config needed to run GUIs from the container
       file: ./docker/gui-compose.yaml
       service: base-gui

--- a/docker/gui-compose.yaml
+++ b/docker/gui-compose.yaml
@@ -1,4 +1,5 @@
 services:
+
   # This base service defines the configuration needed to support GUIs from the container
   base-gui:
     environment:

--- a/docker/gui-compose.yaml
+++ b/docker/gui-compose.yaml
@@ -1,0 +1,23 @@
+services:
+  # This base service defines the configuration needed to support GUIs from the container
+  base-gui:
+    environment:
+
+      # Environment variables to support in-container GUIs
+      - DISPLAY # Pass the DISPLAY environment variable for X11 forwarding
+      - QT_X11_NO_MITSHM=1 # Prevent Qt apps in the container from using X11's MIT-SHM extension
+
+      # Nice-to-have environment variables for other useful settings
+      - TERM # Pass the TERM environment variable specifying the terminal type
+      - color_prompt=yes # Provide a colored prompt in the container
+    
+    devices:
+      - "/dev/dri:/dev/dri" # Map the host's Direct Rendering Infrastructure (DRI) into the container
+
+    volumes:
+      - .:/spot_skills # Mount the current directory (in this project, a ROS workspace)
+      - /tmp/.X11-unix:/tmp/.X11-unix # Mount the X11 Unix socket to support GUIs
+      - /etc/localtime:/etc/localtime:ro # Sync the container's timezone with the host (read-only)
+    
+    stdin_open: true    # docker run -i
+    tty: true           # docker run -t


### PR DESCRIPTION
This branch takes the previous GPU-enabling Docker Compose setup and separates out the "core" GUI-enabling settings into a separate file, `gui-compose.yaml`, which defines the `base-gui` service to store the GUI-related settings. By extending this base service, we can easily create a GPU-less service, and inherit the settings right back into the GPU-enabling service.

Merge branch when:
- [x] New GPU-less container can successfully run GUIs
- [x] Original GPU-enabled container can still run GUIs and access the GPU