### PR TITLE
Update Spot SDK Container to v4.1.0

### DIFF
--- a/.github/workflows/validate-docker.yaml
+++ b/.github/workflows/validate-docker.yaml
@@ -6,6 +6,7 @@ on:
       - "Dockerfile"
       - "compose.yaml"
       - "docker/**"
+      - ".github/workflows/validate-docker.yaml"
 
 jobs:
   Build-All-Docker-Services:

--- a/.github/workflows/validate-docker.yaml
+++ b/.github/workflows/validate-docker.yaml
@@ -18,6 +18,6 @@ jobs:
       - name: List files in the repository
         run: |
           ls ${{ github.workspace }}
-      - name: Build current services using Docker Compose
-        run: docker compose build
+      - name: Build selected Docker Compose services (focus on those with Spot SDK)
+        run: docker compose build spot-sdk spot-moveit
       - run: echo "This job's current status is ${{ job.status }}."

--- a/.github/workflows/validate-docker.yaml
+++ b/.github/workflows/validate-docker.yaml
@@ -21,5 +21,5 @@ jobs:
           ls ${{ github.workspace }}
       - name: Build selected Docker Compose services (focus on those with Spot SDK)
         run: |
-          docker compose build --pull spot-sdk spot-moveit
+          docker compose build spot-sdk spot-moveit
       - run: echo "This job's current status is ${{ job.status }}."

--- a/.github/workflows/validate-docker.yaml
+++ b/.github/workflows/validate-docker.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: List files in the repository
         run: |
           ls ${{ github.workspace }}
-      - name: Build selected Docker Compose services (focus on those with Spot SDK)
+      - name: Build selected Docker Compose services (focus on the Spot SDK image)
         run: |
-          docker compose build spot-sdk spot-moveit
+          docker compose build spot-sdk
       - run: echo "This job's current status is ${{ job.status }}."

--- a/.github/workflows/validate-docker.yaml
+++ b/.github/workflows/validate-docker.yaml
@@ -21,6 +21,5 @@ jobs:
           ls ${{ github.workspace }}
       - name: Build selected Docker Compose services (focus on those with Spot SDK)
         run: |
-          docker compose pull noetic-moveit
-          docker compose build spot-sdk spot-moveit
+          docker compose build --pull spot-sdk spot-moveit
       - run: echo "This job's current status is ${{ job.status }}."

--- a/.github/workflows/validate-docker.yaml
+++ b/.github/workflows/validate-docker.yaml
@@ -19,5 +19,7 @@ jobs:
         run: |
           ls ${{ github.workspace }}
       - name: Build selected Docker Compose services (focus on those with Spot SDK)
-        run: docker compose build spot-sdk spot-moveit
+        run: |
+          docker compose pull noetic-moveit
+          docker compose build spot-sdk spot-moveit
       - run: echo "This job's current status is ${{ job.status }}."

--- a/.github/workflows/validate-docker.yaml
+++ b/.github/workflows/validate-docker.yaml
@@ -18,4 +18,6 @@ jobs:
       - name: List files in the repository
         run: |
           ls ${{ github.workspace }}
+      - name: Build current services using Docker Compose
+        run: docker compose build
       - run: echo "This job's current status is ${{ job.status }}."

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ logs/
 
 # Ignore byte-compiled Python files
 __pycache__/
+
+# Ignore secrets (e.g., passwords, robot IPs, etc.)
+secrets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ARG CUDA_VERSION=12.2.2
 # Enable overriding the base image for non-GPU machines (default uses GPU)
 ARG BASE_IMAGE=nvidia/cuda:${CUDA_VERSION}-base-ubuntu20.04
 
+# Enable overriding the image onto which the Spot SDK is installed
+ARG INSTALL_SPOT_SDK_ONTO=ubuntu-git-py
+
 ## Stage 0: Install Git, Python, and pip onto the base image (Ubuntu 20.04 LTS)
 FROM ${BASE_IMAGE} AS ubuntu-git-py
 
@@ -73,8 +76,11 @@ RUN echo "source /moveit_ws/devel/setup.bash" >> ~/.bashrc
 # Finalize the default working directory for the image
 WORKDIR /spot_skills
 
-## Stage B1: Install the Spot SDK and its dependencies onto the Ubuntu-Git image
-FROM ubuntu-git-py AS spot-sdk
+# For the next stage, renew the ARG specifying the image onto which the Spot SDK is installed
+ARG INSTALL_SPOT_SDK_ONTO
+
+## Stage B1/A3: Install the Spot SDK and its dependencies onto the selected image (default is Ubuntu-Git)
+FROM ${INSTALL_SPOT_SDK_ONTO} AS spot-sdk
 ARG SPOT_SDK_VERSION
 
 # Clone the Spot SDK from GitHub

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,8 @@ RUN git config --global http.sslVerify "false" && \
 VOLUME /spot_sdk
 
 # Install the Boston Dynamics Python packages (needed to work with Spot)
-RUN python3 -m pip install \
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install \
     bosdyn-client==${SPOT_SDK_VERSION} \
     bosdyn-mission==${SPOT_SDK_VERSION} \
     bosdyn-choreography-client==${SPOT_SDK_VERSION} \

--- a/compose.yaml
+++ b/compose.yaml
@@ -42,6 +42,9 @@ services:
       target: spot-sdk
       args:
         BASE_IMAGE: ubuntu:20.04 # Use a base image without GPU support
-        SPOT_SDK_VERSION: 4.0.3 # Specifies the Spot Python package versions
+        SPOT_SDK_VERSION: 4.1.0 # Specifies the Spot Python package versions
     
     image: bennedh/spot-skills:spot-sdk
+
+    volumes:
+      - .:/spot_skills # Mount this repository into the container (for file access)

--- a/compose.yaml
+++ b/compose.yaml
@@ -61,6 +61,8 @@ services:
       args:
         BASE_IMAGE: ubuntu:20.04 # Use a base image without GPU support
         SPOT_SDK_VERSION: 4.1.0 # Specifies the Spot Python package versions
+
+        # Install the Spot SDK onto the stage that has ROS 1 Noetic and MoveIt
         INSTALL_SPOT_SDK_ONTO: noetic-moveit
     
     image: bennedh/spot-skills:spot-moveit

--- a/compose.yaml
+++ b/compose.yaml
@@ -48,3 +48,22 @@ services:
 
     volumes:
       - .:/spot_skills # Mount this repository into the container (for file access)
+
+  # Container providing the Spot SDK alongside ROS 1 Noetic and MoveIt (no GPU support)
+  spot-moveit:
+    extends: # Add config for GUIs and useful terminal properties
+      file: ./docker/core-compose.yaml
+      service: base-gui
+
+    build:
+      context: .
+      target: spot-sdk
+      args:
+        BASE_IMAGE: ubuntu:20.04 # Use a base image without GPU support
+        SPOT_SDK_VERSION: 4.1.0 # Specifies the Spot Python package versions
+        INSTALL_SPOT_SDK_ONTO: noetic-moveit
+    
+    image: bennedh/spot-skills:spot-moveit
+
+    volumes:
+      - .:/spot_skills # Mount this repository (a ROS workspace) into the container


### PR DESCRIPTION
This branch adds changes that increment the Spot SDK version to 4.1.0, alongside related changes creating an image that installs the Spot SDK onto the existing Noetic-MoveIt image.